### PR TITLE
build: fix .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+
+build/


### PR DESCRIPTION
## Description
`.gitignore`にTypeScriptのビルド先ディレクトリを追加します。

## Related issues
#5 